### PR TITLE
Diberry/0109 twitter

### DIFF
--- a/ClientApp/.vscode/launch.json
+++ b/ClientApp/.vscode/launch.json
@@ -1,0 +1,40 @@
+{
+    // Debug client, with requests to server, w/o 
+    // having to change CORS on server
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Edge against localhost",
+            "request": "launch",
+            "type": "pwa-msedge",
+            "url": "http://localhost:3000",
+            "webRoot": "${workspaceFolder}",
+            "runtimeArgs": [
+                "--disable-web-security"
+            ],
+        },
+        {
+            "name": "Test via NPM",
+            "request": "launch",
+            "runtimeArgs": [
+                "run-script",
+                "test"
+            ],
+            "runtimeExecutable": "npm",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "type": "pwa-node"
+        },
+        {
+            "type": "pwa-chrome",
+            "request": "launch",
+            "name": "Launch Chrome against localhost",
+            "url": "http://localhost:3000",
+            "webRoot": "${workspaceFolder}",
+            "runtimeArgs": [
+                "--disable-web-security"
+            ],
+        }
+    ]
+}

--- a/ClientApp/package.json
+++ b/ClientApp/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "start": "rimraf ./build && react-scripts start",
     "build": "react-scripts build",
-    "test": "cross-env CI=true react-scripts test --env=jsdom",
+    "test": "cross-env CI=true react-scripts test --env=jsdom --coverage",
     "eject": "react-scripts eject",
     "lint": "eslint ./src/"
   },

--- a/ClientApp/src/components/Account.js
+++ b/ClientApp/src/components/Account.js
@@ -130,7 +130,6 @@ export class Account extends Component {
                     <div className="list-group">
                         {
                             this.state.handles.map((handle, idx) => <AccountPane 
-                                key={idx}
                                 handle={handle} 
                                 idx={idx}
                                 disableAutoTweets={(handle, idx) => this.disableAutoTweets(handle, idx)}

--- a/ClientApp/src/components/Account.js
+++ b/ClientApp/src/components/Account.js
@@ -130,6 +130,7 @@ export class Account extends Component {
                     <div className="list-group">
                         {
                             this.state.handles.map((handle, idx) => <AccountPane 
+                                key={idx}
                                 handle={handle} 
                                 idx={idx}
                                 disableAutoTweets={(handle, idx) => this.disableAutoTweets(handle, idx)}

--- a/ClientApp/src/components/tweet-components/WebjobPostedBlock.js
+++ b/ClientApp/src/components/tweet-components/WebjobPostedBlock.js
@@ -1,6 +1,66 @@
-﻿import React, { Component } from 'react';
+﻿import React, { Component, Link } from 'react';
+import { getTweetUrl } from '../utils/twitter-tweet-util';
 
 export class WebjobPostedBlock extends Component {
+
+    constructor(props) {
+        super(props);
+
+        this.openNewTabOnClick = this.openNewTabOnClick.bind(this);
+
+        this.state = {
+            tweetUrl: null,
+            linkEnabled: false
+        }
+    }
+
+    async componentDidMount() {
+        const tweetId = (this.props.tweet && this.props.tweet.TweetId && this.props.tweet.TweetId.length > 0)
+            ? this.props.tweet.TweetId
+            : null;
+        
+        const tweetUrl = (tweetId != null)
+            ? getTweetUrl(this.props.tweet)
+            : null;
+        
+        const linkEnabled = (this.props.tweet && this.props.tweet.TweetId && this.props.tweet.TweetId.length>0)
+            ? true
+            : false;
+
+        this.setState({
+            tweetUrl,
+            linkEnabled
+        });
+    }
+
+    openNewTabOnClick() {
+        window.open(this.state.tweetUrl, "_blank", 'noopener,noreferrer')
+    }
+
+    // If internal record has a value for external TweetId, 
+    // then convert icon to a link that opens a new tab using 
+    // the external twitter id
+    //
+    // Styling follows pattern of "Create Tweet" button on Compose
+    tweetIconWithLink() {
+
+        const buttonStyle = this.state.linkEnabled
+            ? { border: 0, padding: 0 }
+            : { border: 0, padding: 0, opacity: .65, cursor: 'not-allowed' };
+
+        return (
+
+            <button
+                id={`button`}
+                data-testid={`button`}
+                onClick={this.openNewTabOnClick}
+                disabled={!this.state.linkEnabled} style={buttonStyle}>
+                
+                <i className="fab fa-twitter-square fa-lg twitter" ></i>
+            </button>
+        )
+    }
+
     render() {
         if (this.props.tweet.IsPostedByWebJob && !this.props.editPaneExpanded) {
             if (this.props.canEdit) {
@@ -9,7 +69,7 @@ export class WebjobPostedBlock extends Component {
                         <span>
                             {
                                 this.props.tweet.RetweetNum === 0 ?
-                                    <i className="fab fa-twitter-square fa-lg twitter"></i> :
+                                    this.tweetIconWithLink() :
                                     <i className="fas fa-retweet fa-lg twitter"></i>
                             }
                         </span>
@@ -20,13 +80,11 @@ export class WebjobPostedBlock extends Component {
                 );
             } else {
                 return (
-                    <div className="mt-2">
-                        <i className="fab fa-twitter-square fa-lg twitter"></i>
-                    </div>
+                    this.tweetIconWithLink()
                 );
             }
         } else {
-            return null;
+            return (<></>);
         }
     }
 }

--- a/ClientApp/src/components/tweet-components/__tests__/WebJobPostedBlock.test.js
+++ b/ClientApp/src/components/tweet-components/__tests__/WebJobPostedBlock.test.js
@@ -2,6 +2,7 @@
 import { render, unmountComponentAtNode } from "react-dom";
 import { act } from "react-dom/test-utils";
 import { WebjobPostedBlock } from '../WebjobPostedBlock.js';
+import { mount } from 'enzyme';
 
 let container = null;
 beforeEach(() => {
@@ -38,4 +39,56 @@ it("Webjob section doesn't render during editing, and renders correctly when pos
     });
 
     expect(container.querySelector("[data-testid='webjob-pane']")).toBeNull();
+});
+
+describe("WebJobPostedBlock - Twitter Icon", () => {
+
+    // 3 States:
+    // Posted without external twitter id - older tweets - not enabled
+    // Posted with external twitter id - newer tweets - enabled
+    // Tweets not posted yet do not show icon
+
+    it("Twitter icon area displays correctly with button enabled", () => {
+
+        // posted tweet with tweetId is enabled
+        let tweet = {
+            IsPostedByWebJob: true,
+            Id: 123,
+            TweetId: "XYZ"
+        };
+
+        const myComponent = mount(<WebjobPostedBlock tweet={tweet} editPaneExpanded={false} canEdit={false} />);
+
+        const myButton = myComponent.find("[data-testid='button']");
+        expect(myButton).toBeDefined();
+        expect(myButton.prop('disabled')).toBe(false);
+    });
+    it("Twitter icon area displays correctly with button disabled", () => {
+
+        // posted tweet without tweetId is NOT enabled
+        let tweet = {
+            IsPostedByWebJob: true,
+            Id: 123,
+            TweetId: null
+        };
+
+        const myComponent = mount(<WebjobPostedBlock tweet={tweet} editPaneExpanded={false} canEdit={false} />);
+
+        const myButton = myComponent.find("[data-testid='button']");
+        expect(myButton).toBeDefined();
+        expect(myButton.prop('disabled')).toBe(true);
+    });
+
+    it("Twitter icon area displays correctly without button b/c tweet isn't posted", () => {
+        let tweet = {
+            IsPostedByWebJob: false,
+            Id: 123,
+            TweetId: ""
+        };
+        const myComponent = mount(<WebjobPostedBlock tweet={tweet} editPaneExpanded={false} canEdit={false} />);
+
+        const myButton = myComponent.find("[data-testid='button']");
+        expect(myButton).toEqual({});;
+    });
+
 });

--- a/ClientApp/src/components/utils/twitter-tweet-util.js
+++ b/ClientApp/src/components/utils/twitter-tweet-util.js
@@ -1,0 +1,18 @@
+// Param - internal Tweet object from database
+// Return either:
+//     Link to user's public twitter
+//     Link to exact tweet using external tweet id 
+export const getTweetUrl = (tweet) => {
+
+    if (tweet.TwitterHandle
+        && tweet.Id
+        && tweet.TweetId) {
+
+        return `https://twitter.com/${tweet.TwitterHandle}/status/${tweet.TweetId}`;
+
+    } else {
+        // if tweet isn't posted yet, return link to account
+        return `https://twitter.com/${tweet.TwitterHandle}`; 
+    }
+
+}


### PR DESCRIPTION
1. Add coverage to test in package.json
2. Add CORS security disabling in launch.json so I can run full-stack locally
3. Wrap twitter icon for posted tweets with button to tweet on twitter
4. Add tests to verify button states

![image](https://user-images.githubusercontent.com/41597107/104215732-0a983080-53ee-11eb-85ff-6d4dab0ee2a9.png)

 PASS  src/components/__tests__/Compose.test.js (5.814s)
 PASS  src/components/tweet-components/__tests__/WebJobPostedBlock.test.js (6.043s)
 PASS  src/components/tweet-components/__tests__/BasicTweetBlock.test.js (6.678s)
 PASS  src/components/__tests__/Accounts.test.js
 PASS  src/components/tweet-components/__tests__/EditPaneBlock.test.js
 PASS  src/components/tweet-components/__tests__/TweetApproveCancelBlock.test.js

Test Suites: 6 passed, 6 total
Tests:       29 passed, 29 total
Snapshots:   0 total
Time:        16.349s
Ran all test suites.